### PR TITLE
check 'machine()' for both amd64 and arm64

### DIFF
--- a/src/pre_commit_buildifier.py
+++ b/src/pre_commit_buildifier.py
@@ -17,7 +17,7 @@ def get_processor():
     if platform.machine().lower() in ["amd64", "x86_64"]:
         return "amd64"
 
-    if platform.processor().lower() in ["arm64", "aarch64"]:
+    if platform.machine().lower() in ["arm64", "aarch64"]:
         return "arm64"
 
     raise NotImplementedError(f"Target CPU/OS is not supported: {platform.machine()}")


### PR DESCRIPTION
Hey @Warchant ; it seem that `platform.processor()` (returning a value such as "arm") won't ever produce ["arm64", "aarch64"]; changing to `platform.machine()` should offer a better chance of detecting an ARM process.

I think this snuck in with #10 -- researching in that PR, it looks like the discussion acknowledges this error, but the discussion ends without an obvious fix.  I assume this delta is what @blackliner was suggesting.