### PR TITLE
Pass all args with double dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ repos:
 ```
 
 run with specific buildifier version and args:
+
 ```yaml
 repos:
 -   repo: https://github.com/warchant/pre-commit-buildifier
     rev: 0.1.3
     hooks:
     -   id: buildifier
-        args: [--version, "v6.3.2", -mode=fix]
+        args: [--version, "v6.3.2", --mode=fix]
 ```

--- a/src/pre_commit_buildifier.py
+++ b/src/pre_commit_buildifier.py
@@ -123,7 +123,7 @@ def main():
     args, extra = parser.parse_known_args()
 
     buildifier_bin = get_buildifier(args)
-    subprocess.check_call([buildifier_bin, "-lint=fix"] + extra + args.file)
+    subprocess.check_call([buildifier_bin, "--lint=fix"] + extra + args.file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://github.com/bazelbuild/buildtools/blob/main/buildifier/README.md#linter uses double `--` for all CLI args, so the hook should follow this pattern.