### PR TITLE
Use return code over exception thrown

### DIFF
--- a/src/pre_commit_buildifier.py
+++ b/src/pre_commit_buildifier.py
@@ -123,7 +123,7 @@ def main():
     args, extra = parser.parse_known_args()
 
     buildifier_bin = get_buildifier(args)
-    subprocess.check_call([buildifier_bin, "--lint=fix"] + extra + args.file)
+    return subprocess.run([buildifier_bin, "--lint=fix"] + extra + args.file).returncode
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
So far, if buildifier returns a non zero exit code, e.g when running as linter (#14), `check_output` will throw an exception and the user will get a very ugly error message including the stack trace and all files pre-commit was executed on. With this change, the user will only see the buildifier output and the exit code.